### PR TITLE
Fix kernel driver build for linux 5.0 to 5.14

### DIFF
--- a/driver/hddsuperclone_driver.c
+++ b/driver/hddsuperclone_driver.c
@@ -1602,7 +1602,7 @@ static long process_ioctl(struct file *f, const unsigned cmd, const unsigned lon
         data_major_num = 0;
         goto out;
       }
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0)
       // Needed for Kernel 5.15
       data_device.gd = __alloc_disk_node(data_queue, NUMA_NO_NODE, &super_bio_compl_lkclass);
 #else


### PR DESCRIPTION
Installed Debian stable 11.4 and found out that the kernel version 5.10 is not supported by the hddsuperclone kernel driver. This is just a quick fix to get builds working. 