### PR TITLE
Fix segfault due to massive stack allocation

### DIFF
--- a/hddscviewer2.c
+++ b/hddscviewer2.c
@@ -3076,7 +3076,7 @@ int get_block_information(long long position, long long size)
     //message_now(tempmessage);
     return -1;
   }
-  int maxcount = 4096;
+  int maxcount = 64;
   long long nontried = 0;
   long long nontrimmed = 0;
   long long nondivided = 0;


### PR DESCRIPTION
hddscviewer attempts to allocate a massive 24MB of stack memory to provide a buffer for a gtk_label, this makes the allocation a more reasonable size and should fix the crash related to clicking on a square to view its details.