### PR TITLE
Make libcurl an optional dependency, add makefile for windows build

### DIFF
--- a/Makefile.windows
+++ b/Makefile.windows
@@ -1,6 +1,6 @@
 CC = gcc 
-CFLAGS = -Wall -Wextra -O2 -fsanitize=address,undefined -Wno-deprecated-declarations
-GTKFLAGS = `pkg-config --cflags --libs gtk+-2.0` -export-dynamic
+CFLAGS = -Wall -Wextra -O2 -Wno-deprecated-declarations
+GTKFLAGS = `pkg-config --cflags --libs gtk+-2.0`
 
 all : hddscviewer2.c
 	xxd -i hddscviewer2.glade hddscviewer2_glade.h

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -1,0 +1,8 @@
+CC = gcc 
+CFLAGS = -Wall -Wextra -O2 -fsanitize=address,undefined -Wno-deprecated-declarations
+GTKFLAGS = `pkg-config --cflags --libs gtk+-2.0` -export-dynamic
+
+all : hddscviewer2.c
+	xxd -i hddscviewer2.glade hddscviewer2_glade.h
+	$(CC) $(CFLAGS) hddscviewer2.c -o hddscviewer $(GTKFLAGS)
+	

--- a/clone_gui2.c
+++ b/clone_gui2.c
@@ -617,6 +617,7 @@ void get_data_dump_filename_ccc(void)
 
 
 #ifdef DEBUG
+#ifdef USE_CURL
 static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
 {
   size_t realsize = size * nmemb;
@@ -635,6 +636,7 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, voi
 
   return realsize;
 }
+#endif
 #endif
 
 
@@ -1016,6 +1018,10 @@ int translate_language_ccc(char *fromlang, char *translang, char *language, char
 char* get_translated_data_ccc(char *url_data)
 {
  #ifdef DEBUG
+  #ifndef USE_CURL
+   return url_data;
+  #else
+
   do_nanosleep_ccc(TRANSLATETIMERALL);  // this is a timer to deal with google translator
   CURL *curl_handle;
   CURLcode res;
@@ -1066,6 +1072,7 @@ char* get_translated_data_ccc(char *url_data)
   curl_global_cleanup();
 
   return chunk.memory;
+  #endif
 #else
   return url_data;
 #endif

--- a/clone_gui2.h
+++ b/clone_gui2.h
@@ -7,7 +7,9 @@
 #include <gtk/gtk.h>
 #include "conditional.h"
 #ifdef DEBUG
+#ifdef USE_CURL
 #include <curl/curl.h>
+#endif
 #endif
 #include <stdio.h>
 #include <stdlib.h>

--- a/hddscviewer2.c
+++ b/hddscviewer2.c
@@ -3747,6 +3747,7 @@ static void file_import_sel( char *import_file )
 
 
 #ifdef DEBUG
+#ifdef USE_CURL
 static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
 {
   size_t realsize = size * nmemb;
@@ -3765,6 +3766,7 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, voi
 
   return realsize;
 }
+#endif
 #endif
 
 
@@ -4132,6 +4134,9 @@ int translate_language(char *fromlang, char *translang, char *language, char *na
 char* get_translated_data(char *url_data)
 {
 #ifdef DEBUG
+#ifndef USE_CURL
+  return url_data;
+#else
   do_nanosleep(TRANSLATETIMERALL);  // this is a timer to deal with google translator
   CURL *curl_handle;
   CURLcode res;
@@ -4182,6 +4187,7 @@ char* get_translated_data(char *url_data)
   curl_global_cleanup();
 
   return chunk.memory;
+#endif
 #else
   return url_data;
 #endif

--- a/hddscviewer2.h
+++ b/hddscviewer2.h
@@ -20,7 +20,9 @@
 #include <cairo.h>
 #include "conditional.h"
 #ifdef DEBUG
+#ifdef USE_CURL
 #include <curl/curl.h>
+#endif
 #endif
 #include <sys/stat.h>
 

--- a/makefile
+++ b/makefile
@@ -93,10 +93,6 @@ $(PROG30) : $(PROG30)$(GTKVER).c
 	$(OFFICEVER) --headless --convert-to html:HTML hddscviewer.odt
 	$(OFFICEVER) --headless --convert-to pdf:writer_pdf_Export hddscviewer.odt
 
-windows : hddscviewer2.c
-	xxd -i hddscviewer2.glade hddscviewer2_glade.h
-	$(CC) -Wall -Wextra -O2 -fsanitize=address,undefined -Wno-deprecated-declarations hddscviewer2.c -o hddscviewer $(GTKFLAGS)
-	
 server : $(PROG20).c
 	xxd -i $(PROG00)_help.txt $(PROG00)_help.h
 	xxd -i $(PROG20)_help.txt $(PROG20)_help.h

--- a/makefile
+++ b/makefile
@@ -18,7 +18,7 @@ else
 CFLAGS = -Wall -W -Wno-deprecated-declarations
 endif
 USBFLAGS = -lusb
-CURLFLAGS = -lcurl
+CURLFLAGS = -DUSE_CURL -lcurl
 GTKFLAGS = `pkg-config --cflags --libs gtk+-$(GTKVER).0` -export-dynamic
 PROG00 = hddsupertool
 PROG01 = commands
@@ -93,7 +93,9 @@ $(PROG30) : $(PROG30)$(GTKVER).c
 	$(OFFICEVER) --headless --convert-to html:HTML hddscviewer.odt
 	$(OFFICEVER) --headless --convert-to pdf:writer_pdf_Export hddscviewer.odt
 
-
+windows : hddscviewer2.c
+	xxd -i hddscviewer2.glade hddscviewer2_glade.h
+	$(CC) -Wall -Wextra -O2 -fsanitize=address,undefined -Wno-deprecated-declarations hddscviewer2.c -o hddscviewer $(GTKFLAGS)
 	
 server : $(PROG20).c
 	xxd -i $(PROG00)_help.txt $(PROG00)_help.h


### PR DESCRIPTION
libcurl dependency is enabled by default for linux builds and disabled by default for windows builds. Windows build works with msys2 and mingw compiler using the default msys gtk2 package. Windows build can be compiled with "make -f Makefile.windows"