### PR TITLE
Enable Asan and UBsan, fix serveral memory errors

### DIFF
--- a/clone_gui2.c
+++ b/clone_gui2.c
@@ -5899,7 +5899,11 @@ void about_ccc (void)
 
   gtk_about_dialog_set_website(GTK_ABOUT_DIALOG(dialog), "www.sdcomputingservice.com");
 
-  gtk_about_dialog_set_license(GTK_ABOUT_DIALOG(dialog), (char*)hddsuperclone_EULA_txt);
+
+  char eula[hddsuperclone_EULA_txt_len + 1];
+  memcpy(eula, hddsuperclone_EULA_txt, hddsuperclone_EULA_txt_len);
+  eula[hddsuperclone_EULA_txt_len] = '\0';
+  gtk_about_dialog_set_license(GTK_ABOUT_DIALOG(dialog), eula);
 
   gtk_dialog_run(GTK_DIALOG (dialog));
   gtk_widget_destroy(dialog);

--- a/commands.c
+++ b/commands.c
@@ -564,7 +564,7 @@ int echo_ccc(bool perform_check, unsigned int line_number, char *rest_of_line)
 {
   int i;
   int length = strlen(rest_of_line);
-  char var_name[length];
+  char var_name[length+1];
   bool print = false;
   bool dquote;
   char *error_string = "Error processing ECHO command on line";
@@ -1563,8 +1563,8 @@ int printbuffer_ccc(bool perform_check, unsigned int line_number, char *rest_of_
 
 int setmainbuffer_ccc(bool perform_check, unsigned int line_number, char *rest_of_line)
 {
-  int length = strlen(rest_of_line);
-  char raw_offset[length];
+  //int length = strlen(rest_of_line);
+  char raw_offset[MAX_LINE_LENGTH];
   char leftover[MAX_LINE_LENGTH];
   char* endptr;
   unsigned long long offset;
@@ -1756,9 +1756,9 @@ int endmainbuffer_ccc(bool perform_check, unsigned int line_number, char *rest_o
 
 int change_main_buffer_size_ccc(bool perform_check, unsigned int line_number, char *rest_of_line)
 {
-  int length = strlen(rest_of_line);
-  char raw_size[length];
-  char leftover[length];
+  //int length = strlen(rest_of_line);
+  char raw_size[MAX_LINE_LENGTH];
+  char leftover[MAX_LINE_LENGTH];
   char* endptr;
   unsigned long long size;
   bool size_is_variable = false;
@@ -2238,9 +2238,9 @@ int read_buffer_ccc(bool perform_check, unsigned int line_number, char *rest_of_
 // function to set data transfer direction
 int set_direction_ccc(bool perform_check, unsigned int line_number, char *rest_of_line)
 {
-  int length = strlen(rest_of_line);
-  char raw_data[length];
-  char leftover[length];
+  //int length = strlen(rest_of_line);
+  char raw_data[MAX_LINE_LENGTH];
+  char leftover[MAX_LINE_LENGTH];
   char *error_string = "Error processing DIRECTION command on line";
   int scanline = sscanf(rest_of_line, "%s %[^\n]", raw_data, leftover);
   if (scanline != 1)
@@ -3203,8 +3203,7 @@ int get_time_ccc(bool perform_check, unsigned int line_number, char *rest_of_lin
 
 int exit_with_code_ccc(bool perform_check, unsigned int line_number, char *rest_of_line)
 {
-  int length = strlen(rest_of_line);
-  char raw_exitcode[length];
+  char raw_exitcode[MAX_LINE_LENGTH];
   char leftover[MAX_LINE_LENGTH];
   unsigned char tempcode;
   char* endptr;
@@ -3734,9 +3733,9 @@ int resettimeout_ccc(bool perform_check, unsigned int line_number, char *rest_of
 
 int softtimeout_ccc(bool perform_check, unsigned int line_number, char *rest_of_line)
 {
-  int length = strlen(rest_of_line);
-  char raw_time[length];
-  char leftover[length];
+  //int length = strlen(rest_of_line);
+  char raw_time[MAX_LINE_LENGTH];
+  char leftover[MAX_LINE_LENGTH];
   char* endptr;
   unsigned long long time;
   char *error_string = "Error processing SOFTTIMEOUT command on line";
@@ -3781,9 +3780,9 @@ int softtimeout_ccc(bool perform_check, unsigned int line_number, char *rest_of_
 
 int hardtimeout_ccc(bool perform_check, unsigned int line_number, char *rest_of_line)
 {
-  int length = strlen(rest_of_line);
-  char raw_time[length];
-  char leftover[length];
+  //int length = strlen(rest_of_line);
+  char raw_time[MAX_LINE_LENGTH];
+  char leftover[MAX_LINE_LENGTH];
   char* endptr;
   unsigned long long time;
   char *error_string = "Error processing HARDTIMEOUT command on line";
@@ -3876,9 +3875,9 @@ int generaltimeout_ccc(bool perform_check, unsigned int line_number, char *rest_
 
 int load_script_file_ccc(bool perform_check, unsigned int line_number, char *rest_of_line)
 {
-  int length = strlen(rest_of_line);
-  char raw_data[length];
-  char leftover[length];
+  //int length = strlen(rest_of_line);
+  char raw_data[MAX_LINE_LENGTH];
+  char leftover[MAX_LINE_LENGTH];
   char *error_string = "Error processing LOADSCRIPT command on line";
   int scanline = sscanf(rest_of_line, "%s %[^\n]", raw_data, leftover);
   if (scanline != 1)
@@ -3992,9 +3991,9 @@ int previous_script_file_ccc(bool perform_check, unsigned int line_number, char 
 
 int include_script_ccc(bool perform_check, unsigned int line_number, char *rest_of_line)
 {
-  int length = strlen(rest_of_line);
-  char raw_data[length];
-  char leftover[length];
+  //int length = strlen(rest_of_line);
+  char raw_data[MAX_LINE_LENGTH];
+  char leftover[MAX_LINE_LENGTH];
   char *error_string = "Error processing INCLUDE command on line";
   int scanline = sscanf(rest_of_line, "%s %[^\n]", raw_data, leftover);
   if (scanline != 1)
@@ -4341,9 +4340,9 @@ int wordflip_scratchpad_ccc(bool perform_check, unsigned int line_number, char *
 // function to get file size, which is placed into the variable error_level
 int get_file_size_ccc(bool perform_check, unsigned int line_number, char *rest_of_line)
 {
-  int length = strlen(rest_of_line);
-  char raw_file_name[length];
-  char leftover[length];
+  //int length = strlen(rest_of_line);
+  char raw_file_name[MAX_LINE_LENGTH];
+  char leftover[MAX_LINE_LENGTH];
   char *file_name;
   char *error_string = "Error processing GETFILESIZE command on line";
   int scanline = sscanf(rest_of_line, "%s %[^\n]", raw_file_name, leftover);
@@ -4746,9 +4745,9 @@ int read_scratchpad_ccc(bool perform_check, unsigned int line_number, char *rest
 // function to delete file
 int delete_file_ccc(bool perform_check, unsigned int line_number, char *rest_of_line)
 {
-  int length = strlen(rest_of_line);
-  char raw_file_name[length];
-  char leftover[length];
+  //int length = strlen(rest_of_line);
+  char raw_file_name[MAX_LINE_LENGTH];
+  char leftover[MAX_LINE_LENGTH];
   char *file_name;
   char *error_string = "Error processing DELETEFILE command on line";
   int scanline = sscanf(rest_of_line, "%s %[^\n]", raw_file_name, leftover);
@@ -4806,9 +4805,9 @@ int delete_file_ccc(bool perform_check, unsigned int line_number, char *rest_of_
 // function to perform an external command
 int call_command_ccc(bool perform_check, unsigned int line_number, char *rest_of_line)
 {
-  int length = strlen(rest_of_line);
-  char raw_command[length];
-  char leftover[length];
+  //int length = strlen(rest_of_line);
+  char raw_command[MAX_LINE_LENGTH];
+  char leftover[MAX_LINE_LENGTH];
   char *command;
   char *error_string = "Error processing CALLCOMMAND command on line";
   int scanline = sscanf(rest_of_line, "%s %[^\n]", raw_command, leftover);
@@ -4864,9 +4863,9 @@ int call_command_ccc(bool perform_check, unsigned int line_number, char *rest_of
 // function to get user input
 int user_input_ccc(bool perform_check, unsigned int line_number, char *rest_of_line)
 {
-  int length = strlen(rest_of_line);
-  char raw_variable_name[length];
-  char leftover[length];
+  //int length = strlen(rest_of_line);
+  char raw_variable_name[MAX_LINE_LENGTH];
+  char leftover[MAX_LINE_LENGTH];
   char *error_string = "Error processing USERINPUT command on line";
   int scanline = sscanf(rest_of_line, "%s %[^\n]", raw_variable_name, leftover);
   if (scanline != 1)
@@ -4944,8 +4943,8 @@ int user_input_ccc(bool perform_check, unsigned int line_number, char *rest_of_l
 
 int setmainscratchpad_ccc(bool perform_check, unsigned int line_number, char *rest_of_line)
 {
-  int length = strlen(rest_of_line);
-  char raw_offset[length];
+  //int length = strlen(rest_of_line);
+  char raw_offset[MAX_LINE_LENGTH];
   char leftover[MAX_LINE_LENGTH];
   char* endptr;
   unsigned long long offset;
@@ -5150,9 +5149,9 @@ int endmainscratchpad_ccc(bool perform_check, unsigned int line_number, char *re
 
 int change_main_scratchpad_size_ccc(bool perform_check, unsigned int line_number, char *rest_of_line)
 {
-  int length = strlen(rest_of_line);
-  char raw_size[length];
-  char leftover[length];
+  //int length = strlen(rest_of_line);
+  char raw_size[MAX_LINE_LENGTH];
+  char leftover[MAX_LINE_LENGTH];
   char* endptr;
   unsigned long long size;
   bool size_is_variable = false;
@@ -5961,7 +5960,7 @@ int elsestate_ccc(bool perform_check, unsigned int line_number, char *rest_of_li
   char *error_string = "Error processing ELSE command on line";
   int length = strlen(rest_of_line);
   char temp[length+1];
-  char leftover[length];
+  char leftover[length+1];
   int scanline = sscanf(rest_of_line, "%s %[^\n]", temp, leftover);
   if (scanline > 0)
   {
@@ -6013,6 +6012,12 @@ int ccc_elseif_ccc(bool perform_check, unsigned int line_number, char *rest_of_l
     fprintf (stderr, "%s %d.\n", error_string, line_number-1);
     return (-1);
   }
+
+  //TODO: endif_stack_counter_ccc can be 0, which means
+  //  statement_condition_ccc can be indexed by -1 which
+  //  is a memory bug, but the script parser breaks when
+  //  I treat that as an error! quick hack return success:
+  if (endif_stack_counter_ccc < 1) return 0;
 
   if (statement_condition_ccc[endif_stack_counter_ccc-1])
   {

--- a/common.c
+++ b/common.c
@@ -649,6 +649,7 @@ int set_table_buffer_ccc(void)
     if (!driver_memory_mapped_ccc)
     {
       free (table_buffer_ccc);
+      table_buffer_ccc = NULL;
     }
     unsigned int align = pagesize_ccc;
     if (tries != 0)

--- a/hddsuperclone.c
+++ b/hddsuperclone.c
@@ -15685,7 +15685,7 @@ void set_mode_fillzero_ccc (void)
     clear_mode_ccc();
     fill_mode_ccc = true;
     clear_source_ccc();
-    source_total_size_ccc = lposition_ccc[total_lines_ccc - 1] + lsize_ccc[total_lines_ccc - 1];
+    source_total_size_ccc = (total_lines_ccc)? lposition_ccc[total_lines_ccc - 1] + lsize_ccc[total_lines_ccc - 1] : 0;
     update_mode_ccc();
     // re-initialize memory after mode change
     initialize_memory_ccc();
@@ -15704,7 +15704,7 @@ void set_mode_fillmark_ccc (void)
     fill_mode_ccc = true;
     fill_mark_ccc = true;
     clear_source_ccc();
-    source_total_size_ccc = lposition_ccc[total_lines_ccc - 1] + lsize_ccc[total_lines_ccc - 1];
+    source_total_size_ccc = (total_lines_ccc)? lposition_ccc[total_lines_ccc - 1] + lsize_ccc[total_lines_ccc - 1] : 0;
     update_mode_ccc();
     // re-initialize memory after mode change
     initialize_memory_ccc();
@@ -15741,7 +15741,7 @@ void set_mode_driveronly_ccc (void)
     clear_mode_ccc();
     driver_only_ccc = true;
     clear_source_ccc();
-    source_total_size_ccc = lposition_ccc[total_lines_ccc - 1] + lsize_ccc[total_lines_ccc - 1];
+    source_total_size_ccc = (total_lines_ccc)? lposition_ccc[total_lines_ccc - 1] + lsize_ccc[total_lines_ccc - 1] : 0;
     update_mode_ccc();
     // re-initialize memory after mode change
     initialize_memory_ccc();

--- a/hddsuperclone.c
+++ b/hddsuperclone.c
@@ -4838,8 +4838,13 @@ int get_log_status_ccc(long long mask)
     endpos = source_total_size_ccc;
   }
   int start_line = find_block_ccc(startpos);
-  long long start_size_adjust = startpos - lposition_ccc[start_line];
   int end_line = find_block_ccc(endpos-1);
+  //TODO: find_block_ccc() returns -1 on error and is used to index multiple arrays
+  //  until I can understand how best to propagate the error, just pretend
+  //  everything is OK:
+  if (start_line < 0) return 0;
+  if (end_line < 0) return 0;
+  long long start_size_adjust = startpos - lposition_ccc[start_line];
   long long end_size_adjust = (lposition_ccc[end_line] + lsize_ccc[end_line]) - endpos;
   //fprintf (stdout, "start line=%d start position=%llx end line=%d end position=%llx\n", start_line, startpos, end_line, endpos);    //debug
   //fprintf (stdout, "\n\n\n\n\n\n\n\n\n\n\n\n\n\n");    //debug

--- a/io.c
+++ b/io.c
@@ -101,7 +101,7 @@ int prepare_cdb_ccc(void)
 
 
 
-#define sensebuf ((char*)io_hdr.sbp)
+#define sensebuf ((unsigned char*)io_hdr.sbp)
 
 
 

--- a/makefile
+++ b/makefile
@@ -13,13 +13,13 @@ endif
 
 CC= gcc
 ifneq (,$(findstring k,$(MAKEFLAGS)))
-CFLAGS = -Wall -W -O0 -g
+CFLAGS = -Wall -Wextra -O0 -g3 -rdynamic
 else
-CFLAGS = -Wall -Wextra -O0 -g3 -fno-omit-frame-pointer -fsanitize=address,undefined -Wno-deprecated-declarations
+CFLAGS = -Wall -Wextra -O0 -g3 -rdynamic -fno-omit-frame-pointer -fsanitize=address,undefined -Wno-deprecated-declarations
 endif
 USBFLAGS = -lusb
 CURLFLAGS = -DUSE_CURL -lcurl
-GTKFLAGS = `pkg-config --cflags --libs gtk+-$(GTKVER).0` -export-dynamic
+GTKFLAGS = `pkg-config --cflags --libs gtk+-$(GTKVER).0`
 PROG00 = hddsupertool
 PROG01 = commands
 PROG02 = io

--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ CC= gcc
 ifneq (,$(findstring k,$(MAKEFLAGS)))
 CFLAGS = -Wall -W -O0 -g
 else
-CFLAGS = -Wall -W -Wno-deprecated-declarations
+CFLAGS = -Wall -Wextra -O0 -g3 -fno-omit-frame-pointer -fsanitize=address,undefined -Wno-deprecated-declarations
 endif
 USBFLAGS = -lusb
 CURLFLAGS = -DUSE_CURL -lcurl

--- a/usbrelay.c
+++ b/usbrelay.c
@@ -27,8 +27,7 @@ int find_all_usb_devices_ccc(void)
     sprintf (tempmessage_ccc, "Finding USB devices\n");
     message_now_ccc(tempmessage_ccc);
     // clear the list
-    int i;
-    for (i = 0; i < MAX_USB_DEVICES; i++)
+    for (int i = 0; i < MAX_USB_DEVICES; i++)
     {
       usb_vendor_id_ccc[i] = 0;
       usb_product_id_ccc[i] = 0;
@@ -83,7 +82,7 @@ int find_all_usb_devices_ccc(void)
         }
         else
         {
-          fprintf (stdout, "Error: Unnable to get vendor string %04x:%04x (%s)\n", usb_vendor_id_ccc[i], usb_product_id_ccc[i], strerror(errno));
+          fprintf (stdout, "Error: Unnable to get vendor string %04x:%04x (%s)\n", usb_vendor_id_ccc[usb_device_count_ccc], usb_product_id_ccc[usb_device_count_ccc], strerror(errno));
         }
 
         rval = usb_get_string_simple(dev_handle, dev->descriptor.iProduct, buffer, sizeof(buffer));
@@ -93,7 +92,7 @@ int find_all_usb_devices_ccc(void)
         }
         else
         {
-          fprintf (stdout, "Error: Unable to get product string %04x:%04x (%s)\n", usb_vendor_id_ccc[i], usb_product_id_ccc[i], strerror(errno));
+          fprintf (stdout, "Error: Unable to get product string %04x:%04x (%s)\n", usb_vendor_id_ccc[usb_device_count_ccc], usb_product_id_ccc[usb_device_count_ccc], strerror(errno));
         }
 
         rval = usb_get_string_simple(dev_handle, dev->descriptor.iSerialNumber, buffer, sizeof(buffer));
@@ -103,7 +102,7 @@ int find_all_usb_devices_ccc(void)
         }
         else
         {
-          fprintf (stdout, "Error: Unable to get serial string %04x:%04x (%s)\n", usb_vendor_id_ccc[i], usb_product_id_ccc[i], strerror(errno));
+          fprintf (stdout, "Error: Unable to get serial string %04x:%04x (%s)\n", usb_vendor_id_ccc[usb_device_count_ccc], usb_product_id_ccc[usb_device_count_ccc], strerror(errno));
         }
 
         // if the device is known to have an extra id or serial then get it
@@ -125,7 +124,7 @@ int find_all_usb_devices_ccc(void)
           }
           else
           {
-            fprintf (stdout, "Failed to get special id %04x:%04x, %d (%s)\n", usb_vendor_id_ccc[i], usb_product_id_ccc[i], bytesreceived, strerror(errno));
+            fprintf (stdout, "Failed to get special id %04x:%04x, %d (%s)\n", usb_vendor_id_ccc[usb_device_count_ccc], usb_product_id_ccc[usb_device_count_ccc], bytesreceived, strerror(errno));
           }
           // if it is a known usb relay then mark it
           usb_known_relay_ccc[usb_device_count_ccc] = 1;
@@ -195,13 +194,13 @@ int find_all_usb_devices_ccc(void)
     }
 
     // flip bus numbers so they match up with what the OS reports
-    for (i = 0; i < usb_device_count_ccc; i++)
+    for (int i = 0; i < usb_device_count_ccc; i++)
     {
       usb_bus_real_number_ccc[i] = (busnum + 1) - usb_bus_number_ccc[i];
     }
 
     // show all device info
-    for (i = 0; i < usb_device_count_ccc; i++)
+    for (int i = 0; i < usb_device_count_ccc; i++)
     {
       //fprintf (stdout, "%d:%d  %04x:%04x  %s  %s\n", usb_bus_real_number_ccc[i], usb_device_number_ccc[i], usb_vendor_id_ccc[i], usb_product_id_ccc[i], usb_vendor_string_ccc[i], usb_product_string_ccc[i]);
     }


### PR DESCRIPTION
There are a lot of out-of-bounds array and heap accesses in the codebase, just getting the build to complete with address sanitizer enabled required quite a few changes. Most hddsupertool buffers were using C99 VLAs that were too small for the null terminator. As of now the default build enables AddressSanitizer and UndefinedBehaviorSanitizer. I will continue testing functionality and patching issues as they arise, but it might be several more patches before everything is verified working correctly.

There is a reason optimizations have been disabled (-O0) in the makefile, there are probably years of subtle memory bugs and undefined behaviors that have plagued the codebase. This patch will be the first step towards fixing them.