### PR TITLE
Fix out-of-bounds write in generic device mode

### DIFF
--- a/io.c
+++ b/io.c
@@ -6580,7 +6580,7 @@ int find_all_devices_ccc(void)
       strcpy (drive_list_ccc[device_count_ccc], "/dev/");
       strcat (drive_list_ccc[device_count_ccc], name);
       strncpy (model_ccc[device_count_ccc], model, sizeof(model_ccc)/MAX_DEVICES);
-      //  get device info
+      // get device info
       long long size = strtoull(raw_size, NULL, 0);
       long long bytes_per_sec = strtoull(raw_bytes_per_sec, NULL, 0);
       drive_size_ccc[device_count_ccc] = size;

--- a/io.c
+++ b/io.c
@@ -6579,8 +6579,8 @@ int find_all_devices_ccc(void)
       sscanf(line, "%s %s %s %[^\n]", name, raw_size, raw_bytes_per_sec, model);
       strcpy (drive_list_ccc[device_count_ccc], "/dev/");
       strcat (drive_list_ccc[device_count_ccc], name);
-      strncpy (model_ccc[device_count_ccc], model, sizeof(model_ccc));
-      // get device info
+      strncpy (model_ccc[device_count_ccc], model, sizeof(model_ccc)/MAX_DEVICES);
+      //  get device info
       long long size = strtoull(raw_size, NULL, 0);
       long long bytes_per_sec = strtoull(raw_bytes_per_sec, NULL, 0);
       drive_size_ccc[device_count_ccc] = size;


### PR DESCRIPTION
I need to audit the use of strncpy() everywhere it is used in the source code. "strncpy(dest, src, num)" is almost never the correct solution to copy a string to a limited size buffer because it is guaranteed to write no less than "num" bytes to "dest" and not guaranteed to NULL terminate.