### PR TITLE
Fix a couple small issues with build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ The Live-CD is using the following software:
 
 
 Building:
-* sudo apt-get install git make gcc libusb-dev libgtk-3-dev libcurl4-openssl-dev texi2html help2man
-* git clone github.com/thesourcerer8/hddsuperclone
+* sudo apt-get install git make gcc libusb-dev libgtk-3-dev libcurl4-openssl-dev libbsd-dev texi2html help2man
+* git clone https://github.com/thesourcerer8/hddsuperclone
 * cd hddsuperclone
 * make
 * sudo ./hddsuperclone


### PR DESCRIPTION
Original clone command failure:

$ git clone github.com/thesourcerer8/hddsuperclone fatal: repository 'github.com/thesourcerer8/hddsuperclone' does not exist

Original make command failure:

$ make
gcc -Wall -Wextra -O2 -g3 -rdynamic -fno-omit-frame-pointer -fsanitize=address,undefined -Wno-deprecated-declarations create_script_help.c -o create_script_help -lbsd /usr/bin/ld: cannot find -lbsd: No such file or directory collect2: error: ld returned 1 exit status
make: *** [makefile:59: create_script_help] Error 1